### PR TITLE
chore: update release workflow to include build step

### DIFF
--- a/.changeset/cuddly-jokes-unite.md
+++ b/.changeset/cuddly-jokes-unite.md
@@ -1,0 +1,9 @@
+---
+'@cli-upkaran/adapter-filesystem': patch
+'@cli-upkaran/adapter-website': patch
+'@cli-upkaran/cli': patch
+'@cli-upkaran/core': patch
+'@cli-upkaran/dataprep-core': patch
+'@cli-upkaran/digest': patch
+'@cli-upkaran/fetch': patch
+---

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,9 +34,8 @@ jobs:
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile
 
-      # Optional: Build step if needed before publishing
-      # - name: Build Packages
-      #   run: pnpm run build
+      - name: Build Packages
+        run: pnpm run build
 
       - name: Create Release Pull Request or Publish to npm
         id: changesets


### PR DESCRIPTION
- Re-enabled the build step in the release workflow to ensure packages are built before publishing.